### PR TITLE
Add `vpc_id` as variable instead of using data source in `alb` module

### DIFF
--- a/examples/alb-with-instance-target-group/main.tf
+++ b/examples/alb-with-instance-target-group/main.tf
@@ -28,6 +28,7 @@ module "alb" {
 
   is_public       = false
   ip_address_type = "IPV4"
+  vpc_id          = data.aws_vpc.default.id
   network_mapping = {
     for az, subnet in data.aws_subnet.default :
     az => {

--- a/examples/alb-with-ip-target-group/main.tf
+++ b/examples/alb-with-ip-target-group/main.tf
@@ -28,6 +28,7 @@ module "alb" {
 
   is_public       = false
   ip_address_type = "IPV4"
+  vpc_id          = data.aws_vpc.default.id
   network_mapping = {
     for az, subnet in data.aws_subnet.default :
     az => {

--- a/examples/nlb-with-alb-target-group/alb.tf
+++ b/examples/nlb-with-alb-target-group/alb.tf
@@ -11,6 +11,7 @@ module "alb" {
 
   is_public       = false
   ip_address_type = "IPV4"
+  vpc_id          = data.aws_vpc.default.id
   network_mapping = {
     for az, subnet in data.aws_subnet.default :
     az => {

--- a/modules/alb/README.md
+++ b/modules/alb/README.md
@@ -42,6 +42,7 @@ This module creates following resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name of the load balancer. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen. | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) The ID of the VPC which the load balancer belongs to. | `string` | n/a | yes |
 | <a name="input_access_log_enabled"></a> [access\_log\_enabled](#input\_access\_log\_enabled) | (Optional) Indicates whether to enable access logs. Defaults to `false`, even when bucket is specified. | `bool` | `false` | no |
 | <a name="input_access_log_s3_bucket"></a> [access\_log\_s3\_bucket](#input\_access\_log\_s3\_bucket) | (Optional) The name of the S3 bucket used to store the access logs. | `string` | `null` | no |
 | <a name="input_access_log_s3_key_prefix"></a> [access\_log\_s3\_key\_prefix](#input\_access\_log\_s3\_key\_prefix) | (Optional) The key prefix for the specified S3 bucket. | `string` | `null` | no |

--- a/modules/alb/security-group.tf
+++ b/modules/alb/security-group.tf
@@ -1,8 +1,3 @@
-locals {
-  vpc_id = values(data.aws_subnet.this)[0].vpc_id
-}
-
-
 ###################################################
 # Security Group for Application Load Balancer
 ###################################################
@@ -11,7 +6,7 @@ module "security_group" {
   source  = "tedilabs/network/aws//modules/security-group"
   version = "~> 0.25.0"
 
-  vpc_id = local.vpc_id
+  vpc_id = var.vpc_id
 
   name        = try(var.default_security_group.name, local.metadata.name)
   description = try(var.default_security_group.description, "Managed by Terraform.")

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -45,6 +45,11 @@ variable "security_groups" {
   default     = []
 }
 
+variable "vpc_id" {
+  description = "(Required) The ID of the VPC which the load balancer belongs to."
+  type        = string
+}
+
 variable "network_mapping" {
   description = <<EOF
   (Optional) The configuration for the load balancer how routes traffic to targets in which subnets, and in accordance with IP address settings. Select at least two Availability Zone and one subnet for each zone. The load balancer will route traffic only to targets in the selected Availability Zones. Zones that are not supported by the load balancer or VPC cannot be selected. Subnets can be added, but not removed, once a load balancer is created. Each key of `network_mapping` is the availability zone id like `apne2-az1`, `use1-az1`. Each value of `network_mapping` block as defined below.


### PR DESCRIPTION
### Background

- Fix the issue related to the dependency of the `default_security_group` in `alb` module.