### PR TITLE
Change to use `count` instead of `for_each` in `nlb-alb-target-group` and `alb-lambda-target-group`

### DIFF
--- a/examples/nlb-with-alb-target-group/main.tf
+++ b/examples/nlb-with-alb-target-group/main.tf
@@ -75,7 +75,7 @@ module "target_group" {
 
   targets = [
     {
-      alb = module.alb.name
+      alb = module.alb.arn
     }
   ]
 
@@ -88,11 +88,11 @@ module "target_group" {
     path                = "/ping"
   }
 
-  depends_on = [
-    module.alb,
-  ]
-
   tags = {
     "project" = "terraform-aws-load-balancer-examples"
   }
+
+  depends_on = [
+    module.alb,
+  ]
 }

--- a/modules/alb-lambda-target-group/README.md
+++ b/modules/alb-lambda-target-group/README.md
@@ -45,7 +45,7 @@ No modules.
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
-| <a name="input_targets"></a> [targets](#input\_targets) | (Optional) A set of targets to add to the target group. The Lambda target group is limited to a single Lambda function target. The load balancer starts routing requests to a newly registered target as soon as the registration process completes and the target passes the initial health checks (if enabled). Each value of `targets` block as defined below.<br>    (Required) `lambda_function` - The Amazon Resource Name (ARN) of the target Lambda. If your ARN does not specify a version or alias, the latest version ($LATEST) will be used by default. ARNs that specify a version / alias do so after the function name, and are separated by a colon. | `set(map(string))` | `[]` | no |
+| <a name="input_targets"></a> [targets](#input\_targets) | (Optional) A list of targets to add to the target group. The Lambda target group is limited to a single Lambda function target. The load balancer starts routing requests to a newly registered target as soon as the registration process completes and the target passes the initial health checks (if enabled). Each value of `targets` block as defined below.<br>    (Required) `lambda_function` - The Amazon Resource Name (ARN) of the target Lambda. If your ARN does not specify a version or alias, the latest version ($LATEST) will be used by default. ARNs that specify a version / alias do so after the function name, and are separated by a colon. | `list(map(string))` | `[]` | no |
 
 ## Outputs
 
@@ -57,6 +57,6 @@ No modules.
 | <a name="output_health_check"></a> [health\_check](#output\_health\_check) | Health Check configuration of the target group. |
 | <a name="output_id"></a> [id](#output\_id) | The ID of the target group. |
 | <a name="output_name"></a> [name](#output\_name) | The name of the target group. |
-| <a name="output_targets"></a> [targets](#output\_targets) | A set of targets in the target group. The Lambda target group is limited to a single Lambda function target. |
+| <a name="output_targets"></a> [targets](#output\_targets) | A list of targets in the target group. The Lambda target group is limited to a single Lambda function target. |
 | <a name="output_type"></a> [type](#output\_type) | The target type of the target group. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/alb-lambda-target-group/main.tf
+++ b/modules/alb-lambda-target-group/main.tf
@@ -64,15 +64,12 @@ resource "aws_lb_target_group" "this" {
 # INFO: Not supported attributes
 # - `port`
 resource "aws_lb_target_group_attachment" "this" {
-  for_each = {
-    for target in var.targets :
-    target.lambda_function => target
-  }
+  count = length(var.targets) > 0 ? 1 : 0
 
   target_group_arn = aws_lb_target_group.this.arn
 
   # TODO: divide function name and alias
-  target_id         = each.value.lambda_function
+  target_id         = var.targets[0].lambda_function
   availability_zone = "all"
 
   depends_on = [
@@ -86,12 +83,9 @@ resource "aws_lb_target_group_attachment" "this" {
 ###################################################
 
 resource "aws_lambda_permission" "this" {
-  for_each = {
-    for target in var.targets :
-    target.lambda_function => target
-  }
+  count = length(var.targets) > 0 ? 1 : 0
 
-  function_name = each.value.lambda_function
+  function_name = var.targets[0].lambda_function
 
   statement_id_prefix = "AllowExecutionFromALB-"
   principal           = "elasticloadbalancing.amazonaws.com"

--- a/modules/alb-lambda-target-group/outputs.tf
+++ b/modules/alb-lambda-target-group/outputs.tf
@@ -24,10 +24,12 @@ output "type" {
 }
 
 output "targets" {
-  description = "A set of targets in the target group. The Lambda target group is limited to a single Lambda function target."
+  description = "A list of targets in the target group. The Lambda target group is limited to a single Lambda function target."
   value = [
     for target in aws_lb_target_group_attachment.this : {
-      lambda_function = target.target_id
+      lambda_function = {
+        arn = target.target_id
+      }
     }
   ]
 }

--- a/modules/alb-lambda-target-group/variables.tf
+++ b/modules/alb-lambda-target-group/variables.tf
@@ -10,10 +10,10 @@ variable "name" {
 
 variable "targets" {
   description = <<EOF
-  (Optional) A set of targets to add to the target group. The Lambda target group is limited to a single Lambda function target. The load balancer starts routing requests to a newly registered target as soon as the registration process completes and the target passes the initial health checks (if enabled). Each value of `targets` block as defined below.
+  (Optional) A list of targets to add to the target group. The Lambda target group is limited to a single Lambda function target. The load balancer starts routing requests to a newly registered target as soon as the registration process completes and the target passes the initial health checks (if enabled). Each value of `targets` block as defined below.
     (Required) `lambda_function` - The Amazon Resource Name (ARN) of the target Lambda. If your ARN does not specify a version or alias, the latest version ($LATEST) will be used by default. ARNs that specify a version / alias do so after the function name, and are separated by a colon.
   EOF
-  type        = set(map(string))
+  type        = list(map(string))
   default     = []
 
   validation {

--- a/modules/nlb-alb-target-group/README.md
+++ b/modules/nlb-alb-target-group/README.md
@@ -45,7 +45,7 @@ No modules.
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
-| <a name="input_targets"></a> [targets](#input\_targets) | (Optional) A set of targets to add to the target group. The ALB target group is limited to a single Application Load Balancer target. Each value of `targets` block as defined below.<br>    (Required) `alb` - The name of the target ALB (Application Load Balancer). | `set(map(string))` | `[]` | no |
+| <a name="input_targets"></a> [targets](#input\_targets) | (Optional) A list of targets to add to the target group. The ALB target group is limited to a single Application Load Balancer target. Each value of `targets` block as defined below.<br>    (Required) `alb` - The Amazon Resource Name (ARN) of the target ALB (Application Load Balancer). | `list(map(string))` | `[]` | no |
 
 ## Outputs
 
@@ -59,7 +59,7 @@ No modules.
 | <a name="output_name"></a> [name](#output\_name) | The name of the target group. |
 | <a name="output_port"></a> [port](#output\_port) | The port number on which the target receive trrafic. |
 | <a name="output_protocol"></a> [protocol](#output\_protocol) | The protocol to use to connect with the target. |
-| <a name="output_targets"></a> [targets](#output\_targets) | A set of targets in the target group. The ALB target group is limited to a single Application Load Balancer target. |
+| <a name="output_targets"></a> [targets](#output\_targets) | A list of targets in the target group. The ALB target group is limited to a single Application Load Balancer target. |
 | <a name="output_type"></a> [type](#output\_type) | The target type of the target group. |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC which the target group belongs to. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/nlb-alb-target-group/main.tf
+++ b/modules/nlb-alb-target-group/main.tf
@@ -16,9 +16,9 @@ locals {
 
 
 data "aws_lb" "this" {
-  for_each = toset(try(var.targets.*.alb, []))
+  count = length(var.targets) > 0 ? 1 : 0
 
-  name = each.value
+  arn = var.targets[0].alb
 }
 
 # INFO: Not supported attributes
@@ -77,13 +77,10 @@ resource "aws_lb_target_group" "this" {
 # INFO: Not supported attributes
 # - `availability_zone`
 resource "aws_lb_target_group_attachment" "this" {
-  for_each = {
-    for target in var.targets :
-    target.alb => target
-  }
+  count = length(var.targets) > 0 ? 1 : 0
 
   target_group_arn = aws_lb_target_group.this.arn
 
-  target_id = data.aws_lb.this[each.value.alb].arn
+  target_id = var.targets[0].alb
   port      = var.port
 }

--- a/modules/nlb-alb-target-group/outputs.tf
+++ b/modules/nlb-alb-target-group/outputs.tf
@@ -39,12 +39,12 @@ output "protocol" {
 }
 
 output "targets" {
-  description = "A set of targets in the target group. The ALB target group is limited to a single Application Load Balancer target."
+  description = "A list of targets in the target group. The ALB target group is limited to a single Application Load Balancer target."
   value = [
-    for name, target in aws_lb_target_group_attachment.this : {
+    for idx, target in aws_lb_target_group_attachment.this : {
       alb = {
         arn  = target.target_id
-        name = name
+        name = data.aws_lb.this[idx].name
       }
       port = target.port
     }

--- a/modules/nlb-alb-target-group/variables.tf
+++ b/modules/nlb-alb-target-group/variables.tf
@@ -28,10 +28,10 @@ variable "port" {
 
 variable "targets" {
   description = <<EOF
-  (Optional) A set of targets to add to the target group. The ALB target group is limited to a single Application Load Balancer target. Each value of `targets` block as defined below.
-    (Required) `alb` - The name of the target ALB (Application Load Balancer).
+  (Optional) A list of targets to add to the target group. The ALB target group is limited to a single Application Load Balancer target. Each value of `targets` block as defined below.
+    (Required) `alb` - The Amazon Resource Name (ARN) of the target ALB (Application Load Balancer).
   EOF
-  type        = set(map(string))
+  type        = list(map(string))
   default     = []
 
   validation {


### PR DESCRIPTION
### Background

- Terraform always changed outputs the difference without changes.
  - This is because `for_each` is initialized with a set of dynamic input variables.

### Problem Solving

- Use `count` instead of `for_each` in `nlb-alb-target-group` and `alb-lambda-target-group`
  - Do not use dynamic input variable for the iterating key.