### PR TITLE
Fix to use target group arn instead of name in `nlb`

### DIFF
--- a/examples/nlb-with-alb-target-group/main.tf
+++ b/examples/nlb-with-alb-target-group/main.tf
@@ -42,7 +42,7 @@ module "nlb" {
   listeners = [{
     port         = 80
     protocol     = "TCP"
-    target_group = module.target_group.name
+    target_group = module.target_group.arn
   }]
 
   access_log_enabled       = false
@@ -52,10 +52,6 @@ module "nlb" {
   tags = {
     "project" = "terraform-aws-load-balancer-examples"
   }
-
-  depends_on = [
-    module.target_group,
-  ]
 }
 
 

--- a/examples/nlb-with-instance-target-group/main.tf
+++ b/examples/nlb-with-instance-target-group/main.tf
@@ -42,7 +42,7 @@ module "nlb" {
   listeners = [{
     port         = 80
     protocol     = "TCP"
-    target_group = module.target_group.name
+    target_group = module.target_group.arn
   }]
 
   access_log_enabled       = false
@@ -52,10 +52,6 @@ module "nlb" {
   tags = {
     "project" = "terraform-aws-load-balancer-examples"
   }
-
-  depends_on = [
-    module.target_group,
-  ]
 }
 
 

--- a/examples/nlb-with-ip-target-group/main.tf
+++ b/examples/nlb-with-ip-target-group/main.tf
@@ -42,7 +42,7 @@ module "nlb" {
   listeners = [{
     port         = 80
     protocol     = "TCP"
-    target_group = module.target_group.name
+    target_group = module.target_group.arn
   }]
 
   access_log_enabled       = false
@@ -52,10 +52,6 @@ module "nlb" {
   tags = {
     "project" = "terraform-aws-load-balancer-examples"
   }
-
-  depends_on = [
-    module.target_group,
-  ]
 }
 
 

--- a/modules/nlb-alb-target-group/README.md
+++ b/modules/nlb-alb-target-group/README.md
@@ -30,7 +30,6 @@ No modules.
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_lb_target_group_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
-| [aws_lb.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb) | data source |
 
 ## Inputs
 

--- a/modules/nlb-alb-target-group/main.tf
+++ b/modules/nlb-alb-target-group/main.tf
@@ -15,12 +15,6 @@ locals {
 }
 
 
-data "aws_lb" "this" {
-  count = length(var.targets) > 0 ? 1 : 0
-
-  arn = var.targets[0].alb
-}
-
 # INFO: Not supported attributes
 # - `connection_termination`
 # - `lambda_multi_value_headers_enabled`

--- a/modules/nlb-alb-target-group/outputs.tf
+++ b/modules/nlb-alb-target-group/outputs.tf
@@ -44,7 +44,7 @@ output "targets" {
     for idx, target in aws_lb_target_group_attachment.this : {
       alb = {
         arn  = target.target_id
-        name = data.aws_lb.this[idx].name
+        name = split("/", target.target_id)[2]
       }
       port = target.port
     }

--- a/modules/nlb-listener/README.md
+++ b/modules/nlb-listener/README.md
@@ -30,8 +30,6 @@ No modules.
 | [aws_lb_listener.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_certificate) | resource |
 | [aws_resourcegroups_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
-| [aws_lb.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb) | data source |
-| [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
 
 ## Inputs
 
@@ -40,7 +38,7 @@ No modules.
 | <a name="input_load_balancer"></a> [load\_balancer](#input\_load\_balancer) | (Required) The ARN of the network load balancer to add the listener. | `string` | n/a | yes |
 | <a name="input_port"></a> [port](#input\_port) | (Required) The number of port on which the listener of load balancer is listening. | `number` | n/a | yes |
 | <a name="input_protocol"></a> [protocol](#input\_protocol) | (Required) The protocol for connections from clients to the load balancer. Valid values are `TCP`, `TLS`, `UDP` and `TCP_UDP`. Not valid to use `UDP` or `TCP_UDP` if dual-stack mode is enabled on the load balancer. | `string` | n/a | yes |
-| <a name="input_target_group"></a> [target\_group](#input\_target\_group) | (Required) The name of the target group to which to route traffic. | `string` | n/a | yes |
+| <a name="input_target_group"></a> [target\_group](#input\_target\_group) | (Required) The ARN of the target group to which to route traffic. | `string` | n/a | yes |
 | <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
 | <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
 | <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |

--- a/modules/nlb-listener/main.tf
+++ b/modules/nlb-listener/main.tf
@@ -15,16 +15,8 @@ locals {
 }
 
 
-data "aws_lb" "this" {
-  arn = var.load_balancer
-}
-
-data "aws_lb_target_group" "this" {
-  name = var.target_group
-}
-
 locals {
-  load_balancer_name = data.aws_lb.this.name
+  load_balancer_name = split("/", var.load_balancer)[2]
   tls_enabled        = var.protocol == "TLS"
 }
 
@@ -41,7 +33,7 @@ resource "aws_lb_listener" "this" {
 
   default_action {
     type             = "forward"
-    target_group_arn = data.aws_lb_target_group.this.arn
+    target_group_arn = var.target_group
   }
 
   tags = merge(

--- a/modules/nlb-listener/outputs.tf
+++ b/modules/nlb-listener/outputs.tf
@@ -28,10 +28,8 @@ output "default_action" {
   value = {
     type = "FORWARD"
     forward = {
-      arn      = data.aws_lb_target_group.this.arn
-      name     = data.aws_lb_target_group.this.name
-      port     = data.aws_lb_target_group.this.port
-      protocol = data.aws_lb_target_group.this.protocol
+      arn  = var.target_group
+      name = split("/", var.target_group)[1]
     }
   }
 }

--- a/modules/nlb-listener/variables.tf
+++ b/modules/nlb-listener/variables.tf
@@ -19,7 +19,7 @@ variable "protocol" {
 }
 
 variable "target_group" {
-  description = "(Required) The name of the target group to which to route traffic."
+  description = "(Required) The ARN of the target group to which to route traffic."
   type        = string
 }
 


### PR DESCRIPTION
### Background

- Use target group arn instead of name in `nlb`
- Related to #37 