### PR TITLE
Support preserve_host_header for alb module

### DIFF
--- a/modules/alb-instance-target-group/variables.tf
+++ b/modules/alb-instance-target-group/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) Name of the target group. A maximum of 32 alphanumeric characters including hyphens are allowed, but the name must not begin or end with a hyphen."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -16,6 +17,7 @@ variable "vpc_id" {
 variable "port" {
   description = "(Required) The number of port on which targets receive traffic, unless overridden when registering a specific target. Valid values are either ports 1-65535."
   type        = number
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -29,6 +31,7 @@ variable "port" {
 variable "protocol" {
   description = "(Required) The protocol to use for routing traffic to the targets. Valid values are `HTTP` and `HTTPS`. Defaults to `HTTP`."
   type        = string
+  nullable    = false
 
   validation {
     condition     = contains(["HTTP", "HTTPS"], var.protocol)
@@ -40,6 +43,7 @@ variable "protocol_version" {
   description = "(Optional) Use `HTTP1` to send requests to targets using HTTP/1.1. Supported when the request protocol is HTTP/1.1 or HTTP/2. Use `HTTP2` to send requests to targets using HTTP/2. Supported when the request protocol is HTTP/2 or gRPC, but gRPC-specific features are not available. Use `GRPC` to send requests to targets using gRPC. Supported when the request protocol is gRPC. Defaults to `HTTP1`."
   type        = string
   default     = "HTTP1"
+  nullable    = false
 
   validation {
     condition     = contains(["HTTP1", "HTTP2", "GRPC"], var.protocol_version)
@@ -55,12 +59,14 @@ variable "targets" {
   EOF
   type        = set(map(string))
   default     = []
+  nullable    = false
 }
 
 variable "deregistration_delay" {
   description = "(Optional) The time to wait for in-flight requests to complete while deregistering a target. During this time, the state of the target is draining."
   type        = number
   default     = 300
+  nullable    = false
 
   validation {
     condition     = var.deregistration_delay <= 3600 && var.deregistration_delay >= 0
@@ -72,6 +78,7 @@ variable "load_balancing_algorithm" {
   description = "(Optional) Determines how the load balancer selects targets when routing requests. Valid values are `ROUND_ROBIN` or `LEAST_OUTSTANDING_REQUESTS`. Defaults to `ROUND_ROBIN`."
   type        = string
   default     = "ROUND_ROBIN"
+  nullable    = false
 
   validation {
     condition     = contains(["ROUND_ROBIN", "LEAST_OUTSTANDING_REQUESTS"], var.load_balancing_algorithm)
@@ -83,6 +90,7 @@ variable "slow_start_duration" {
   description = "(Optional) The amount time for a newly registered targets to warm up before the load balancer sends them a full share of requests. During this period, targets receives an increasing share of requests until it reaches its fair share. Requires `30` to `900` seconds to enable, or `0` seconds to disable. This attribute cannot be combined with the Least outstanding requests algorithm."
   type        = number
   default     = 0
+  nullable    = false
 
   validation {
     condition = anytrue([
@@ -97,12 +105,14 @@ variable "stickiness_enabled" {
   description = "(Optional) Whether to enable the type of stickiness associated with this target group. If enabled, the load balancer binds a client’s session to a specific instance within the target group. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "stickiness_type" {
   description = "(Optional) The type of sticky sessions. Valid values are `LB_COOKIE` or `APP_COOKIE`. Defaults to `LB_COOKIE`."
   type        = string
   default     = "LB_COOKIE"
+  nullable    = false
 
   validation {
     condition     = contains(["LB_COOKIE", "APP_COOKIE"], var.stickiness_type)
@@ -114,6 +124,7 @@ variable "stickiness_duration" {
   description = "(Optional) The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. Valid values are from `1` to `604800` (1 week). Defaults to `86400` (1 day)."
   type        = number
   default     = 86400
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -144,6 +155,7 @@ variable "health_check" {
   EOF
   type        = any
   default     = {}
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -168,12 +180,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -185,16 +199,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/alb-instance-target-group/versions.tf
+++ b/modules/alb-instance-target-group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/alb-ip-target-group/variables.tf
+++ b/modules/alb-ip-target-group/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) Name of the target group. A maximum of 32 alphanumeric characters including hyphens are allowed, but the name must not begin or end with a hyphen."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -16,6 +17,7 @@ variable "vpc_id" {
 variable "port" {
   description = "(Required) The number of port on which targets receive traffic, unless overridden when registering a specific target. Valid values are either ports 1-65535."
   type        = number
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -29,6 +31,7 @@ variable "port" {
 variable "protocol" {
   description = "(Required) The protocol to use for routing traffic to the targets. Valid values are `HTTP` and `HTTPS`. Defaults to `HTTP`."
   type        = string
+  nullable    = false
 
   validation {
     condition     = contains(["HTTP", "HTTPS"], var.protocol)
@@ -40,6 +43,7 @@ variable "protocol_version" {
   description = "(Optional) Use `HTTP1` to send requests to targets using HTTP/1.1. Supported when the request protocol is HTTP/1.1 or HTTP/2. Use `HTTP2` to send requests to targets using HTTP/2. Supported when the request protocol is HTTP/2 or gRPC, but gRPC-specific features are not available. Use `GRPC` to send requests to targets using gRPC. Supported when the request protocol is gRPC. Defaults to `HTTP1`."
   type        = string
   default     = "HTTP1"
+  nullable    = false
 
   validation {
     condition     = contains(["HTTP1", "HTTP2", "GRPC"], var.protocol_version)
@@ -55,12 +59,14 @@ variable "targets" {
   EOF
   type        = set(map(string))
   default     = []
+  nullable    = false
 }
 
 variable "deregistration_delay" {
   description = "(Optional) The time to wait for in-flight requests to complete while deregistering a target. During this time, the state of the target is draining."
   type        = number
   default     = 300
+  nullable    = false
 
   validation {
     condition     = var.deregistration_delay <= 3600 && var.deregistration_delay >= 0
@@ -72,6 +78,7 @@ variable "load_balancing_algorithm" {
   description = "(Optional) Determines how the load balancer selects targets when routing requests. Valid values are `ROUND_ROBIN` or `LEAST_OUTSTANDING_REQUESTS`. Defaults to `ROUND_ROBIN`."
   type        = string
   default     = "ROUND_ROBIN"
+  nullable    = false
 
   validation {
     condition     = contains(["ROUND_ROBIN", "LEAST_OUTSTANDING_REQUESTS"], var.load_balancing_algorithm)
@@ -83,6 +90,7 @@ variable "slow_start_duration" {
   description = "(Optional) The amount time for a newly registered targets to warm up before the load balancer sends them a full share of requests. During this period, targets receives an increasing share of requests until it reaches its fair share. Requires `30` to `900` seconds to enable, or `0` seconds to disable. This attribute cannot be combined with the Least outstanding requests algorithm."
   type        = number
   default     = 0
+  nullable    = false
 
   validation {
     condition = anytrue([
@@ -97,12 +105,14 @@ variable "stickiness_enabled" {
   description = "(Optional) Whether to enable the type of stickiness associated with this target group. If enabled, the load balancer binds a client’s session to a specific instance within the target group. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "stickiness_type" {
   description = "(Optional) The type of sticky sessions. Valid values are `LB_COOKIE` or `APP_COOKIE`. Defaults to `LB_COOKIE`."
   type        = string
   default     = "LB_COOKIE"
+  nullable    = false
 
   validation {
     condition     = contains(["LB_COOKIE", "APP_COOKIE"], var.stickiness_type)
@@ -114,6 +124,7 @@ variable "stickiness_duration" {
   description = "(Optional) The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. Valid values are from `1` to `604800` (1 week). Defaults to `86400` (1 day)."
   type        = number
   default     = 86400
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -144,6 +155,7 @@ variable "health_check" {
   EOF
   type        = any
   default     = {}
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -168,12 +180,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -185,16 +199,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/alb-ip-target-group/versions.tf
+++ b/modules/alb-ip-target-group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/alb-lambda-target-group/variables.tf
+++ b/modules/alb-lambda-target-group/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) Name of the target group."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -15,6 +16,7 @@ variable "targets" {
   EOF
   type        = list(map(string))
   default     = []
+  nullable    = false
 
   validation {
     condition     = length(var.targets) <= 1
@@ -26,6 +28,7 @@ variable "multi_value_headers_enabled" {
   description = "(Optional) Indicates whether the request and response headers that are exchanged between the load balancer and the Lambda function include arrays of values or strings. Defaults to `false`. If the value is false and the request contains a duplicate header field name or query parameter key, the load balancer uses the last value sent by the client."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "health_check" {
@@ -41,6 +44,7 @@ variable "health_check" {
   EOF
   type        = any
   default     = {}
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -62,12 +66,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -79,16 +85,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/alb-lambda-target-group/versions.tf
+++ b/modules/alb-lambda-target-group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/alb-listener/variables.tf
+++ b/modules/alb-listener/variables.tf
@@ -6,11 +6,13 @@ variable "load_balancer" {
 variable "port" {
   description = "(Required) The number of port on which the listener of load balancer is listening."
   type        = number
+  nullable    = false
 }
 
 variable "protocol" {
   description = "(Required) The protocol for connections from clients to the load balancer. Valid values are `HTTP` and `HTTPS`."
   type        = string
+  nullable    = false
 
   validation {
     condition     = contains(["HTTP", "HTTPS"], var.protocol)
@@ -21,6 +23,7 @@ variable "protocol" {
 variable "default_action_type" {
   description = "(Required) The type of default routing action. Default action apply to traffic that does not meet the conditions of rules on your listener. Rules can be configured after the listener is created. Valid values are `FORWARD`, `WEIGHTED_FORWARD`, `FIXED_RESPONSE`, `REDIRECT_301` and `REDIRECT_302`."
   type        = string
+  nullable    = false
 
   validation {
     condition     = contains(["FORWARD", "WEIGHTED_FORWARD", "FIXED_RESPONSE", "REDIRECT_301", "REDIRECT_302"], var.default_action_type)
@@ -47,6 +50,7 @@ variable "default_action_parameters" {
   EOF
   type        = any
   default     = {}
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -100,7 +104,8 @@ variable "rules" {
     (Optional) `action_parameters` - Same with `default_action_parameters`.
   EOF
   type        = any
-  default     = {}
+  default     = []
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -135,6 +140,7 @@ variable "tls_additional_certificates" {
   description = "(Optional) A set of ARNs of the certificate to attach to the listener. This is for additional certificates and does not replace the default certificate on the listener."
   type        = set(string)
   default     = []
+  nullable    = false
 }
 
 # INFO: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
@@ -142,18 +148,21 @@ variable "tls_security_policy" {
   description = "(Optional) The name of security policy for a Secure Socket Layer (SSL) negotiation configuration. This is used to negotiate SSL connections with clients. Required if protocol is `HTTPS`. Defaults to `ELBSecurityPolicy-2016-08` security policy. The `ELBSecurityPolicy-2016-08` security policy is always used for backend connections. Application Load Balancers do not support custom security policies."
   type        = string
   default     = "ELBSecurityPolicy-2016-08"
+  nullable    = false
 }
 
 variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -165,16 +174,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/alb-listener/versions.tf
+++ b/modules/alb-listener/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -82,6 +82,7 @@ resource "aws_lb" "this" {
   enable_http2               = var.http2_enabled
   enable_waf_fail_open       = var.waf_fail_open_enabled
   idle_timeout               = var.idle_timeout
+  preserve_host_header       = var.preserve_host_header
 
   tags = merge(
     {

--- a/modules/alb/outputs.tf
+++ b/modules/alb/outputs.tf
@@ -104,6 +104,7 @@ output "attributes" {
     http2_enabled               = aws_lb.this.enable_http2
     waf_fail_open_enabled       = aws_lb.this.enable_waf_fail_open
     idle_timeout                = aws_lb.this.idle_timeout
+    preserve_host_header        = aws_lb.this.preserve_host_header
   }
 }
 

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) The name of the load balancer. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -12,12 +13,14 @@ variable "is_public" {
   description = "(Optional) Indicates whether the load balancer will be public. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "ip_address_type" {
   description = "(Optional) The type of IP addresses used by the subnets for your load balancer. The possible values are `IPV4` and `DUALSTACK`."
   type        = string
   default     = "IPV4"
+  nullable    = false
 
   validation {
     condition     = contains(["IPV4", "DUALSTACK"], var.ip_address_type)
@@ -37,12 +40,14 @@ variable "default_security_group" {
   EOF
   type        = any
   default     = {}
+  nullable    = false
 }
 
 variable "security_groups" {
   description = "(Optional) A set of security group IDs to assign to the load balancer."
   type        = set(string)
   default     = []
+  nullable    = false
 }
 
 variable "vpc_id" {
@@ -57,12 +62,14 @@ variable "network_mapping" {
   EOF
   type        = map(map(string))
   default     = {}
+  nullable    = false
 }
 
 variable "access_log_enabled" {
   description = "(Optional) Indicates whether to enable access logs. Defaults to `false`, even when bucket is specified."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "access_log_s3_bucket" {
@@ -74,13 +81,15 @@ variable "access_log_s3_bucket" {
 variable "access_log_s3_key_prefix" {
   description = "(Optional) The key prefix for the specified S3 bucket."
   type        = string
-  default     = null
+  default     = ""
+  nullable    = false
 }
 
 variable "desync_mitigation_mode" {
   description = "(Optional) Determines how the load balancer handles requests that might pose a security risk to your application. Valid values are `DEFENSIVE`, `STRICTEST` and `MONITOR`. Defaults to `DEFENSIVE`."
   type        = string
   default     = "DEFENSIVE"
+  nullable    = false
 
   validation {
     condition     = contains(["DEFENSIVE", "STRICTEST", "MONITOR"], var.desync_mitigation_mode)
@@ -92,30 +101,42 @@ variable "drop_invalid_header_fields" {
   description = "(Optional) Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "deletion_protection_enabled" {
   description = "(Optional) Indicates whether deletion of the load balancer via the AWS API will be protected. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "http2_enabled" {
   description = "(Optional) Indicates whether HTTP/2 is enabled. Defaults to `true`."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "waf_fail_open_enabled" {
   description = "(Optional) Indicates whether to allow a WAF-enabled load balancer to route requests to targets if it is unable to forward the request to AWS WAF. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "idle_timeout" {
   description = "(Optional) The number of seconds before the load balancer determines the connection is idle and closes it. Defaults to `60`"
   type        = number
   default     = 60
+  nullable    = false
+}
+
+variable "preserve_host_header" {
+  description = "(Optional) Indicates whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any change. Defaults to `false`."
+  type        = bool
+  default     = false
+  nullable    = false
 }
 
 variable "listeners" {
@@ -132,18 +153,21 @@ variable "listeners" {
   EOF
   type        = any
   default     = []
+  nullable    = false
 }
 
 variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -155,12 +179,14 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {

--- a/modules/alb/versions.tf
+++ b/modules/alb/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.71"
+      version = ">= 4.25"
     }
   }
 }

--- a/modules/gwlb-instance-target-group/variables.tf
+++ b/modules/gwlb-instance-target-group/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) Name of the target group. A maximum of 32 alphanumeric characters including hyphens are allowed, but the name must not begin or end with a hyphen."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -22,12 +23,14 @@ variable "targets" {
     instance = string
   }))
   default = []
+  nullable    = false
 }
 
 variable "deregistration_delay" {
   description = "(Optional) The time to wait for in-flight requests to complete while deregistering a target. During this time, the state of the target is draining."
   type        = number
   default     = 300
+  nullable    = false
 
   validation {
     condition     = var.deregistration_delay <= 3600 && var.deregistration_delay >= 0
@@ -48,6 +51,7 @@ variable "health_check" {
   EOF
   type        = any
   default     = {}
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -72,12 +76,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -89,16 +95,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/gwlb-instance-target-group/versions.tf
+++ b/modules/gwlb-instance-target-group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/gwlb-ip-target-group/variables.tf
+++ b/modules/gwlb-ip-target-group/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) Name of the target group. A maximum of 32 alphanumeric characters including hyphens are allowed, but the name must not begin or end with a hyphen."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -22,12 +23,14 @@ variable "targets" {
     ip_address = string
   }))
   default = []
+  nullable    = false
 }
 
 variable "deregistration_delay" {
   description = "(Optional) The time to wait for in-flight requests to complete while deregistering a target. During this time, the state of the target is draining."
   type        = number
   default     = 300
+  nullable    = false
 
   validation {
     condition     = var.deregistration_delay <= 3600 && var.deregistration_delay >= 0
@@ -48,6 +51,7 @@ variable "health_check" {
   EOF
   type        = any
   default     = {}
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -72,12 +76,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -89,16 +95,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/gwlb-ip-target-group/versions.tf
+++ b/modules/gwlb-ip-target-group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/gwlb/variables.tf
+++ b/modules/gwlb/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) The name of the load balancer. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -15,18 +16,21 @@ variable "network_mapping" {
   EOF
   type        = map(map(string))
   default     = {}
+  nullable    = false
 }
 
 variable "cross_zone_load_balancing_enabled" {
   description = "(Optional) Cross-zone load balancing distributes traffic evenly across all targets in the Availability Zones enabled for the load balancer. Indicates whether to enable cross-zone load balancing. Defaults to `false`. Regional data transfer charges may apply when cross-zone load balancing is enabled."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "deletion_protection_enabled" {
   description = "(Optional) Indicates whether deletion of the load balancer via the AWS API will be protected. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "listeners" {
@@ -40,6 +44,7 @@ variable "listeners" {
     target_group = string
   }))
   default = []
+  nullable    = false
 
   validation {
     condition     = length(var.listeners) <= 1
@@ -51,12 +56,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -68,16 +75,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/gwlb/versions.tf
+++ b/modules/gwlb/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/nlb-alb-target-group/variables.tf
+++ b/modules/nlb-alb-target-group/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) Name of the target group. A maximum of 32 alphanumeric characters including hyphens are allowed, but the name must not begin or end with a hyphen."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -16,6 +17,7 @@ variable "vpc_id" {
 variable "port" {
   description = "(Optional) The port number on which the targets receive traffic. Valid values are either ports 1-65535."
   type        = number
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -33,6 +35,7 @@ variable "targets" {
   EOF
   type        = list(map(string))
   default     = []
+  nullable    = false
 
   validation {
     condition     = length(var.targets) <= 1
@@ -53,6 +56,7 @@ variable "health_check" {
   EOF
   type        = any
   default     = {}
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -74,12 +78,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -91,16 +97,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/nlb-alb-target-group/versions.tf
+++ b/modules/nlb-alb-target-group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/nlb-instance-target-group/variables.tf
+++ b/modules/nlb-instance-target-group/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) Name of the target group. A maximum of 32 alphanumeric characters including hyphens are allowed, but the name must not begin or end with a hyphen."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -16,6 +17,7 @@ variable "vpc_id" {
 variable "port" {
   description = "(Required) The number of port on which targets receive traffic, unless overridden when registering a specific target. Valid values are either ports 1-65535."
   type        = number
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -29,6 +31,7 @@ variable "port" {
 variable "protocol" {
   description = "(Required) The protocol to use for routing traffic to the targets. Valid values are `TCP`, `TLS`, `UDP` and `TCP_UDP`. Not valid to use `UDP` or `TCP_UDP` if dual-stack mode is enabled on the load balancer."
   type        = string
+  nullable    = false
 
   validation {
     condition     = contains(["TCP", "TLS", "UDP", "TCP_UDP"], var.protocol)
@@ -44,18 +47,21 @@ variable "targets" {
   EOF
   type        = set(map(string))
   default     = []
+  nullable    = false
 }
 
 variable "terminate_connection_on_deregistration" {
   description = "(Optional) Whether to terminate active connections at the end of the deregistration timeout is reached on Network Load Balancers. Enabling this setting is particularly important for `UDP` and `TCP_UDP` target groups. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "deregistration_delay" {
   description = "(Optional) The time to wait for in-flight requests to complete while deregistering a target. During this time, the state of the target is draining."
   type        = number
   default     = 300
+  nullable    = false
 
   validation {
     condition     = var.deregistration_delay <= 3600 && var.deregistration_delay >= 0
@@ -67,18 +73,21 @@ variable "preserve_client_ip" {
   description = "(Optional) Whether to preserve client IP addresses and ports in the packets forwarded to targets. Client IP preservation cannot be disabled if the target group protocol is `UDP` and `TCP_UDP`. Defaults to `true`."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "proxy_protocol_v2" {
   description = "(Optional) Whether to enable support for proxy protocol v2 on Network Load Balancers. Before you enable proxy protocol v2, make sure that your application targets can process proxy protocol headers otherwise your application might break. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "stickiness_enabled" {
   description = "(Optional) Whether to enable the type of stickiness associated with this target group. If enabled, the load balancer binds a client’s session to a specific instance within the target group. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "health_check" {
@@ -94,6 +103,7 @@ variable "health_check" {
   EOF
   type        = any
   default     = {}
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -115,12 +125,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -132,16 +144,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/nlb-instance-target-group/versions.tf
+++ b/modules/nlb-instance-target-group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/nlb-ip-target-group/variables.tf
+++ b/modules/nlb-ip-target-group/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) Name of the target group. A maximum of 32 alphanumeric characters including hyphens are allowed, but the name must not begin or end with a hyphen."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -16,6 +17,7 @@ variable "vpc_id" {
 variable "port" {
   description = "(Required) The number of port on which targets receive traffic, unless overridden when registering a specific target. Valid values are either ports 1-65535."
   type        = number
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -29,6 +31,7 @@ variable "port" {
 variable "protocol" {
   description = "(Required) The protocol to use for routing traffic to the targets. Valid values are `TCP`, `TLS`, `UDP` and `TCP_UDP`. Not valid to use `UDP` or `TCP_UDP` if dual-stack mode is enabled on the load balancer."
   type        = string
+  nullable    = false
 
   validation {
     condition     = contains(["TCP", "TLS", "UDP", "TCP_UDP"], var.protocol)
@@ -44,18 +47,21 @@ variable "targets" {
   EOF
   type        = set(map(string))
   default     = []
+  nullable    = false
 }
 
 variable "terminate_connection_on_deregistration" {
   description = "(Optional) Whether to terminate active connections at the end of the deregistration timeout is reached on Network Load Balancers. Enabling this setting is particularly important for `UDP` and `TCP_UDP` target groups. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "deregistration_delay" {
   description = "(Optional) The time to wait for in-flight requests to complete while deregistering a target. During this time, the state of the target is draining."
   type        = number
   default     = 300
+  nullable    = false
 
   validation {
     condition     = var.deregistration_delay <= 3600 && var.deregistration_delay >= 0
@@ -67,18 +73,21 @@ variable "preserve_client_ip" {
   description = "(Optional) Whether to preserve client IP addresses and ports in the packets forwarded to targets. Client IP preservation cannot be disabled if the target group protocol is `UDP` and `TCP_UDP`. Defaults to `true`."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "proxy_protocol_v2" {
   description = "(Optional) Whether to enable support for proxy protocol v2 on Network Load Balancers. Before you enable proxy protocol v2, make sure that your application targets can process proxy protocol headers otherwise your application might break. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "stickiness_enabled" {
   description = "(Optional) Whether to enable the type of stickiness associated with this target group. If enabled, the load balancer binds a client’s session to a specific instance within the target group. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "health_check" {
@@ -94,6 +103,7 @@ variable "health_check" {
   EOF
   type        = any
   default     = {}
+  nullable    = false
 
   validation {
     condition = alltrue([
@@ -115,12 +125,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -132,16 +144,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/nlb-ip-target-group/versions.tf
+++ b/modules/nlb-ip-target-group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/nlb-listener/variables.tf
+++ b/modules/nlb-listener/variables.tf
@@ -11,6 +11,7 @@ variable "port" {
 variable "protocol" {
   description = "(Required) The protocol for connections from clients to the load balancer. Valid values are `TCP`, `TLS`, `UDP` and `TCP_UDP`. Not valid to use `UDP` or `TCP_UDP` if dual-stack mode is enabled on the load balancer."
   type        = string
+  nullable    = false
 
   validation {
     condition     = contains(["TCP", "TLS", "UDP", "TCP_UDP"], var.protocol)
@@ -33,6 +34,7 @@ variable "tls_additional_certificates" {
   description = "(Optional) A set of ARNs of the certificate to attach to the listener. This is for additional certificates and does not replace the default certificate on the listener."
   type        = set(string)
   default     = []
+  nullable    = false
 }
 
 # INFO: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#describe-ssl-policies
@@ -40,12 +42,14 @@ variable "tls_security_policy" {
   description = "(Optional) The name of security policy for a Secure Socket Layer (SSL) negotiation configuration. This is used to negotiate SSL connections with clients. Required if protocol is `TLS`. Recommend using the `ELBSecurityPolicy-TLS13-1-2-2021-06` security policy. This security policy includes TLS 1.3, which is optimized for security and performance, and is backward compatible with TLS 1.2."
   type        = string
   default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  nullable    = false
 }
 
 variable "tls_alpn_policy" {
   description = "(Optional) The policy of the Application-Layer Protocol Negotiation (ALPN) to select. ALPN is a TLS extension that includes the protocol negotiation within the exchange of hello messages. Can be set if `protocol` is `TLS`. Valid values are `HTTP1Only`, `HTTP2Only`, `HTTP2Optional`, `HTTP2Preferred`, and `None`. Defaults to `None`."
   type        = string
   default     = "None"
+  nullable    = false
 
   validation {
     condition     = contains(["None", "HTTP1Only", "HTTP2Only", "HTTP2Optional", "HTTP2Preferred"], var.tls_alpn_policy)
@@ -57,12 +61,14 @@ variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -74,16 +80,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }

--- a/modules/nlb-listener/versions.tf
+++ b/modules/nlb-listener/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {

--- a/modules/nlb/variables.tf
+++ b/modules/nlb/variables.tf
@@ -1,6 +1,7 @@
 variable "name" {
   description = "(Required) The name of the load balancer. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen."
   type        = string
+  nullable    = false
 
   validation {
     condition     = length(var.name) <= 32
@@ -12,12 +13,14 @@ variable "is_public" {
   description = "(Optional) Indicates whether the load balancer will be public. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "ip_address_type" {
   description = "(Optional) The type of IP addresses used by the subnets for your load balancer. The possible values are `IPV4` and `DUALSTACK`."
   type        = string
   default     = "IPV4"
+  nullable    = false
 
   validation {
     condition     = contains(["IPV4", "DUALSTACK"], var.ip_address_type)
@@ -35,12 +38,14 @@ variable "network_mapping" {
   EOF
   type        = map(map(string))
   default     = {}
+  nullable    = false
 }
 
 variable "access_log_enabled" {
   description = "(Optional) Indicates whether to enable access logs. Defaults to `false`, even when bucket is specified."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "access_log_s3_bucket" {
@@ -52,19 +57,22 @@ variable "access_log_s3_bucket" {
 variable "access_log_s3_key_prefix" {
   description = "(Optional) The key prefix for the specified S3 bucket."
   type        = string
-  default     = null
+  default     = ""
+  nullable    = false
 }
 
 variable "cross_zone_load_balancing_enabled" {
   description = "(Optional) Cross-zone load balancing distributes traffic evenly across all targets in the Availability Zones enabled for the load balancer. Indicates whether to enable cross-zone load balancing. Defaults to `false`. Regional data transfer charges may apply when cross-zone load balancing is enabled."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "deletion_protection_enabled" {
   description = "(Optional) Indicates whether deletion of the load balancer via the AWS API will be protected. Defaults to `false`."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "listeners" {
@@ -80,18 +88,21 @@ variable "listeners" {
   EOF
   type        = any
   default     = []
+  nullable    = false
 }
 
 variable "tags" {
   description = "(Optional) A map of tags to add to all resources."
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "module_tags_enabled" {
   description = "(Optional) Whether to create AWS Resource Tags for the module informations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 
@@ -103,16 +114,19 @@ variable "resource_group_enabled" {
   description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "resource_group_name" {
   description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "resource_group_description" {
   description = "(Optional) The description of Resource Group."
   type        = string
   default     = "Managed by Terraform."
+  nullable    = false
 }


### PR DESCRIPTION
### Background

- Support `preserve_host_header` for `alb` module
- Bump to Terraform version to v1.2