### PR TITLE
chore(deps): align tedilabs child module version constraints with latest releases

### DIFF
--- a/examples/alb-with-instance-target-group/main.tf
+++ b/examples/alb-with-instance-target-group/main.tf
@@ -22,7 +22,7 @@ data "aws_subnet" "default" {
 module "alb" {
   source = "../../modules/alb"
   # source  = "tedilabs/load-balancer/aws//modules/alb"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-alb-instance"
 
@@ -136,7 +136,7 @@ module "alb" {
 module "target_group_alpha" {
   source = "../../modules/alb-instance-target-group"
   # source  = "tedilabs/load-balancer/aws//modules/alb-instance-target-group"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-alb-instance-alpha-tg"
 
@@ -181,7 +181,7 @@ module "target_group_alpha" {
 module "target_group_beta" {
   source = "../../modules/alb-instance-target-group"
   # source  = "tedilabs/load-balancer/aws//modules/alb-instance-target-group"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-alb-instance-beta-tg"
 

--- a/examples/alb-with-ip-target-group/main.tf
+++ b/examples/alb-with-ip-target-group/main.tf
@@ -22,7 +22,7 @@ data "aws_subnet" "default" {
 module "alb" {
   source = "../../modules/alb"
   # source  = "tedilabs/load-balancer/aws//modules/alb"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-alb-ip"
 
@@ -136,7 +136,7 @@ module "alb" {
 module "target_group_alpha" {
   source = "../../modules/alb-ip-target-group"
   # source  = "tedilabs/load-balancer/aws//modules/alb-ip-target-group"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-alb-ip-alpha-tg"
 
@@ -186,7 +186,7 @@ module "target_group_alpha" {
 module "target_group_beta" {
   source = "../../modules/alb-ip-target-group"
   # source  = "tedilabs/load-balancer/aws//modules/alb-ip-target-group"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-alb-ip-beta-tg"
 

--- a/examples/gwlb-with-instance-target-group/main.tf
+++ b/examples/gwlb-with-instance-target-group/main.tf
@@ -22,7 +22,7 @@ data "aws_subnet" "default" {
 module "gwlb" {
   source = "../../modules/gwlb"
   # source  = "tedilabs/load-balancer/aws//modules/gwlb"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-gwlb-instance"
   network_mapping = {
@@ -54,7 +54,7 @@ module "gwlb" {
 module "target_group" {
   source = "../../modules/gwlb-instance-target-group"
   # source  = "tedilabs/load-balancer/aws//modules/gwlb-instance-target-group"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-gwlb-instance-tg"
 

--- a/examples/gwlb-with-ip-target-group/main.tf
+++ b/examples/gwlb-with-ip-target-group/main.tf
@@ -22,7 +22,7 @@ data "aws_subnet" "default" {
 module "gwlb" {
   source = "../../modules/gwlb"
   # source  = "tedilabs/load-balancer/aws//modules/gwlb"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-gwlb-ip"
   network_mapping = {
@@ -54,7 +54,7 @@ module "gwlb" {
 module "target_group" {
   source = "../../modules/gwlb-ip-target-group"
   # source  = "tedilabs/load-balancer/aws//modules/gwlb-ip-target-group"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-gwlb-ip-tg"
 

--- a/examples/nlb-with-alb-target-group/alb.tf
+++ b/examples/nlb-with-alb-target-group/alb.tf
@@ -5,7 +5,7 @@
 module "alb" {
   source = "../../modules/alb"
   # source  = "tedilabs/load-balancer/aws//modules/alb"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-nlb-alb-alb"
 

--- a/examples/nlb-with-alb-target-group/main.tf
+++ b/examples/nlb-with-alb-target-group/main.tf
@@ -22,7 +22,7 @@ data "aws_subnet" "default" {
 module "nlb" {
   source = "../../modules/nlb"
   # source  = "tedilabs/load-balancer/aws//modules/nlb"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-nlb-alb"
 
@@ -67,7 +67,7 @@ module "nlb" {
 module "target_group" {
   source = "../../modules/nlb-alb-target-group"
   # source  = "tedilabs/load-balancer/aws//modules/nlb-alb-target-group"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-nlb-alb-tg"
 

--- a/examples/nlb-with-instance-target-group/main.tf
+++ b/examples/nlb-with-instance-target-group/main.tf
@@ -22,7 +22,7 @@ data "aws_subnet" "default" {
 module "nlb" {
   source = "../../modules/nlb"
   # source  = "tedilabs/load-balancer/aws//modules/nlb"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-nlb-instance"
 
@@ -67,7 +67,7 @@ module "nlb" {
 module "target_group" {
   source = "../../modules/nlb-instance-target-group"
   # source  = "tedilabs/load-balancer/aws//modules/nlb-instance-target-group"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-nlb-instance-tg"
 

--- a/examples/nlb-with-ip-target-group/main.tf
+++ b/examples/nlb-with-ip-target-group/main.tf
@@ -22,7 +22,7 @@ data "aws_subnet" "default" {
 module "nlb" {
   source = "../../modules/nlb"
   # source  = "tedilabs/load-balancer/aws//modules/nlb"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-nlb-ip"
 
@@ -67,7 +67,7 @@ module "nlb" {
 module "target_group" {
   source = "../../modules/nlb-ip-target-group"
   # source  = "tedilabs/load-balancer/aws//modules/nlb-ip-target-group"
-  # version = "~> 1.0.0"
+  # version = "~> 1.5.0"
 
   name = "tedilabs-nlb-ip-tg"
 

--- a/modules/alb/security-group.tf
+++ b/modules/alb/security-group.tf
@@ -15,7 +15,7 @@ locals {
 
 module "security_group" {
   source  = "tedilabs/network/aws//modules/security-group"
-  version = "~> 1.0.0"
+  version = "~> 1.2.0"
 
   count = var.default_security_group.enabled ? 1 : 0
 

--- a/modules/nlb/security-groups.tf
+++ b/modules/nlb/security-groups.tf
@@ -15,7 +15,7 @@ locals {
 
 module "security_group" {
   source  = "tedilabs/network/aws//modules/security-group"
-  version = "~> 1.0.0"
+  version = "~> 1.2.0"
 
   count = var.default_security_group.enabled ? 1 : 0
 


### PR DESCRIPTION
## What & why

The `version` constraints on our sibling `tedilabs` child modules had drifted behind their latest published releases. This realigns them to the house convention of pinning the **minor floor** (`~> MAJOR.MINOR.0`) rather than an exact patch, so patch releases are picked up automatically.

Two groups are touched: the live `tedilabs/network/aws//modules/security-group` calls in `modules/alb` and `modules/nlb`, and the commented-out registry alternatives in `examples/` that document how to consume this repo's own modules from the registry. No behavioural change is expected — see the interface analysis below.

## Changed constraints

### Active module blocks

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/network/aws//modules/security-group` | `modules/alb/security-group.tf:18` | `~> 1.0.0` | `~> 1.2.0` | `v1.2.3` |
| `tedilabs/network/aws//modules/security-group` | `modules/nlb/security-groups.tf:18` | `~> 1.0.0` | `~> 1.2.0` | `v1.2.3` |

### Example docs (commented)

These are commented `# version` lines inside `examples/`; the active `source` in those examples is the local path `../../modules/x`, so these lines are documentation only and have no effect on `terraform` behaviour. They are **self**-references to this repo's own modules.

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/load-balancer/aws//modules/alb` | `examples/alb-with-instance-target-group/main.tf:25` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/alb-instance-target-group` | `examples/alb-with-instance-target-group/main.tf:139` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/alb-instance-target-group` | `examples/alb-with-instance-target-group/main.tf:184` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/alb` | `examples/alb-with-ip-target-group/main.tf:25` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/alb-ip-target-group` | `examples/alb-with-ip-target-group/main.tf:139` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/alb-ip-target-group` | `examples/alb-with-ip-target-group/main.tf:189` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/gwlb` | `examples/gwlb-with-instance-target-group/main.tf:25` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/gwlb-instance-target-group` | `examples/gwlb-with-instance-target-group/main.tf:57` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/gwlb` | `examples/gwlb-with-ip-target-group/main.tf:25` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/gwlb-ip-target-group` | `examples/gwlb-with-ip-target-group/main.tf:57` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/alb` | `examples/nlb-with-alb-target-group/alb.tf:8` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/nlb` | `examples/nlb-with-alb-target-group/main.tf:25` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/nlb-alb-target-group` | `examples/nlb-with-alb-target-group/main.tf:70` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/nlb` | `examples/nlb-with-instance-target-group/main.tf:25` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/nlb-instance-target-group` | `examples/nlb-with-instance-target-group/main.tf:70` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/nlb` | `examples/nlb-with-ip-target-group/main.tf:25` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |
| `tedilabs/load-balancer/aws//modules/nlb-ip-target-group` | `examples/nlb-with-ip-target-group/main.tf:70` | `~> 1.0.0` | `~> 1.5.0` | `v1.5.0` |

## Interface changes between the old and new versions

### `tedilabs/network/aws//modules/security-group`: `v1.0.2` -> `v1.2.3`

Compare: https://github.com/tedilabs/terraform-aws-network/compare/v1.0.2...v1.2.3

**Verdict: BACKWARD_COMPATIBLE. No calling code changed.**

- **Added variables:** none.
- **Removed variables:** none.
- **Renamed/retyped variables:** exactly one change, applied inside both the `ingress_rules` and `egress_rules` element objects — `from_port` and `to_port` went from required `number` to `optional(number)`. This is a pure *relaxation*: every value shape that was valid before is still valid, so both call sites remain correct as written. `modules/alb` and `modules/nlb` both build their listener rules with explicit `from_port`/`to_port` set to `listener.port`, and both also splice in caller-supplied `var.default_security_group.ingress_rules` / `.egress_rules` — the relaxation widens what those caller-supplied rules may contain but rejects nothing that previously worked.
- **Output changes:** none. `outputs.tf` is byte-identical between the two tags.
- **Provider / Terraform version floor:** unchanged. Both tags already declare `required_version = ">= 1.12"` and `hashicorp/aws >= 6.12`, so this repo's own constraints need no adjustment.

Both call sites already pass `resource_group` in the post-`v1.0.0` object form (`resource_group = { enabled = false }`), so the `resource_group_*` -> `resource_group` collapse that made `v1.0.0` a major release is already absorbed and needs no work here.

**Operational note — not applicable to this repo.** Between `v1.0.2` and `v1.2.3` the module's internal RAM share changed shape: `resources` went from a list to a map keyed by `var.name`, the nested `tedilabs/organization/aws//modules/ram-share` dependency moved `~> 0.4.0` -> `~> 0.5.0`, and the share name is now sanitised through `replace(var.name, "/[^a-zA-Z0-9_\\.-]/", "-")`. That would matter for a caller that passes `shares` together with a `name` containing characters outside `[a-zA-Z0-9_.-]`, because the generated RAM share name would change. **Neither `modules/alb` nor `modules/nlb` passes `shares`** (verified by grep), and `shares` defaults to `[]`, so `module.share` has no instances and this cannot produce any plan churn here. Recorded only so reviewers do not have to re-derive it.

For the record, `terraform init` does now vendor `organization/aws//modules/ram-share` at `0.5.6` (was `0.4.2`) as a transitive dependency of the security-group module, even though it instantiates zero resources.

## Verification

- `terraform fmt -recursive -check .` — **passes** (no reformatting needed).
- `modules/alb`: `terraform init -backend=false -upgrade` + `terraform validate` — **Success! The configuration is valid.** `security-group` resolved to **1.2.3** under the new constraint. (The first `validate` attempt failed with a transient `GetProviderSchema request was cancelled` provider-plugin error; a clean re-run succeeded.)
- `modules/nlb`: **could not be validated** — fails for a reason unrelated to this PR, see below.
- All seven touched `examples/` directories: **could not be validated** — all fail for reasons unrelated to this PR, see below.
- All `.terraform` directories and lock files created during verification were removed before committing; `git status --porcelain` shows only the ten intended `.tf` files.
- No `terraform plan` or `apply` was run, so no AWS credentials were used and no live state was consulted. The claim of an empty plan is inferred from the interface diff, not observed.

### Explicit check for stale ALB interface usage in `examples/` — clean

`modules/alb` changed substantially between `v1.0.0` and `v1.5.0`, and because `examples/` calls it through the **local** path `../../modules/alb`, any example still written against the old interface would be a genuine bug rather than a stale comment. Several of those changes are also invisible to `terraform validate`, because `var.listeners` is typed `any` — a leftover flat `tls_certificate` would be silently ignored rather than rejected. I therefore grepped for each one explicitly across `examples/`:

| Old name | Occurrences |
|---|---|
| `tls_certificate` | none |
| `tls_security_policy` | none |
| `tls_additional_certificates` | none |
| `subnet_id` (in `network_mapping`) | none |
| `ingress_cidrs` | none |
| `access_log_*` | none |
| `available_availability_zone_ids` | none |

The examples are already migrated to the current interface: `network_mapping` uses `subnet`, `default_security_group` is written as the closed object with `listener_ingress_ipv4_cidrs`, and every ALB listener element supplies the now-required `default_action_parameters`. Correspondingly, none of the validation errors below originate in an `alb`/`nlb`/`gwlb` module block. **No example needed fixing for the ALB interface.**

### Pre-existing breakage (NOT introduced by this PR, NOT fixed here)

`modules/nlb` and all seven touched `examples/` directories fail `terraform init`/`validate`, and **every one fails identically on an unmodified `origin/main` checkout**. I verified this explicitly in a separate pristine detached worktree at `origin/main` before concluding it was pre-existing — including confirming `modules/nlb` fails the same way with the *old* `~> 1.0.0` constraint resolving `security-group` at `1.0.2`. This PR changes only the security-group constraint plus commented-out `# version` lines, so it cannot be the cause.

Three independent failure classes:

1. **`modules/nlb` -> `modules/nlb-listener` interface mismatch.** `modules/nlb-listener` has been migrated to the `default_action_type` / `default_action_parameters` interface (mirroring the ALB listener refactor in `defe1ef feat(alb): support updated listener`), but `modules/nlb/main.tf:157` still calls it with the old flat `target_group = each.value.target_group` and never supplies the now-required `default_action_type`. This looks like the NLB half of that refactor not having landed yet. It also cascades into `examples/nlb-with-alb-target-group`.
2. **Stale target-group arguments in `examples/`.** `load_balancing_algorithm`, `slow_start_duration`, `stickiness_enabled` (both `alb-with-*-target-group` examples), and `deregistration_delay`, `stickiness_enabled`, `terminate_connection_on_deregistration` (both `nlb-with-instance/ip-target-group` examples) are no longer accepted by the local `*-target-group` modules.
3. **Stale provider pin.** `examples/gwlb-with-instance-target-group` and `examples/gwlb-with-ip-target-group` pin `hashicorp/aws ~> 5.0` in their own `versions.tf` while the local modules now require `>= 6.x`, so provider resolution fails outright before any validation happens.

Class 1 is a real bug on `main` and arguably the most important item here, but fixing it requires a maintainer decision on the intended NLB default-action semantics; classes 2 and 3 mean rewriting the target-group examples and their provider pins. All three are well outside the scope of a version-constraint alignment, so I have deliberately left them alone rather than expanding this PR. Happy to open follow-up issues for each.

## Supersedes

**No open dependabot PR in this repo covers the constraints changed here.** I checked `gh pr list --repo tedilabs/terraform-aws-load-balancer --state open` and none of the 15 open PRs touch `tedilabs/network/aws`:

- #95–#107 (13 PRs) all bump a *different* dependency — `tedilabs/misc/aws` from `~> 0.10.0` to `~> 0.11.0`, one per module directory. Untouched by this PR and still valid on their own terms. Worth noting they are now stale in a different way: `terraform init` already resolves `misc/aws` to `0.12.0` transitively, so those PRs would pin *below* what actually gets used.
- #114 (`tj-actions/changed-files` 44 -> 47) and #115 (`actions/checkout` 4 -> 6) are GitHub Actions bumps, unrelated.

Nothing is superseded and no PRs were closed.
