### PR TITLE
fix(examples): correct terraform and provider version constraints

### DIFF
--- a/examples/alb-with-instance-target-group/versions.tf
+++ b/examples/alb-with-instance-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/alb-with-ip-target-group/versions.tf
+++ b/examples/alb-with-ip-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/gwlb-with-instance-target-group/versions.tf
+++ b/examples/gwlb-with-instance-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/gwlb-with-ip-target-group/versions.tf
+++ b/examples/gwlb-with-ip-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/nlb-with-alb-target-group/versions.tf
+++ b/examples/nlb-with-alb-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/nlb-with-instance-target-group/versions.tf
+++ b/examples/nlb-with-instance-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/nlb-with-ip-target-group/versions.tf
+++ b/examples/nlb-with-ip-target-group/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
## What & why

All 7 example roots in `examples/` pin `hashicorp/aws = "~> 5.0"`, which sets an upper bound of
`< 6.0.0`. The local modules they call (`modules/alb`, `modules/nlb`,
`modules/{alb,nlb,gwlb}-{instance,ip}-target-group`) declare `>= 6.42` (`modules/nlb`: `>= 6.22`).
The intersection is empty, so `terraform init` cannot resolve a provider and the examples are
unusable.

Reproduced verbatim in `examples/gwlb-with-ip-target-group` before the fix:

```
Initializing provider plugins found in the configuration...
- Finding hashicorp/aws versions matching "~> 5.0, >= 6.0.0, >= 6.22.0, >= 6.42.0"...
╷
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider
│ hashicorp/aws: no available releases match the given constraints ~> 5.0, >=
│ 6.0.0, >= 6.22.0, >= 6.42.0
│
│ To see which modules are currently depending on hashicorp/aws and what
│ versions are specified, run the following command:
│     terraform providers
╵
```

## Convention applied

Repo convention, verified unanimous across the already-correct repos in this family:

- terraform: `required_version = "~> x.y"` → `~> 1.12`
- providers: `version = "~> x.0"` → `aws = "~> 6.0"`

`~> 6.0` is sufficient even though modules declare `>= 6.42`: Terraform intersects every constraint
in the module graph, so `~> 6.0` ∩ `>= 6.42` = `[6.42, 7.0)`. Confirmed empirically — the roots that
now init resolve `hashicorp/aws v6.58.0`. No minor floor is pinned into the roots.

## Changed roots

| Example root | `required_version` before → after | `aws` before → after | Why |
| --- | --- | --- | --- |
| `examples/alb-with-instance-target-group` | `~> 1.6` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict (`modules/alb`, `modules/alb-instance-target-group` need `>= 6.42`) |
| `examples/alb-with-ip-target-group` | `~> 1.6` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict (`modules/alb` needs `>= 6.42`) |
| `examples/gwlb-with-instance-target-group` | `~> 1.6` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict (`modules/gwlb-instance-target-group` needs `>= 6.42`) |
| `examples/gwlb-with-ip-target-group` | `~> 1.6` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict (`modules/gwlb-ip-target-group` needs `>= 6.42`) |
| `examples/nlb-with-alb-target-group` | `~> 1.6` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict (`modules/alb` needs `>= 6.42`) |
| `examples/nlb-with-instance-target-group` | `~> 1.6` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict (`modules/nlb-instance-target-group` needs `>= 6.42`) |
| `examples/nlb-with-ip-target-group` | `~> 1.6` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict (`modules/nlb-ip-target-group` needs `>= 6.42`) |

7 roots had an init-breaking conflict; 0 were style-only. Nothing outside
`examples/*/versions.tf` is touched.

## Verification

`terraform fmt -recursive -check .` — passes.

Per root, with a private `TF_PLUGIN_CACHE_DIR`, run serially:

| Example root | Result |
| --- | --- |
| `examples/alb-with-instance-target-group` | `init` still FAILS — pre-existing config errors, see below |
| `examples/alb-with-ip-target-group` | `init` still FAILS — pre-existing config errors, see below |
| `examples/gwlb-with-instance-target-group` | `init` OK, `validate` OK |
| `examples/gwlb-with-ip-target-group` | `init` OK, `validate` OK |
| `examples/nlb-with-alb-target-group` | `init` still FAILS — pre-existing `modules/nlb` bug, see below |
| `examples/nlb-with-instance-target-group` | `init` still FAILS — pre-existing config errors, see below |
| `examples/nlb-with-ip-target-group` | `init` still FAILS — pre-existing config errors, see below |

**Being explicit: this PR does not make CI green for 5 of the 7 roots.** It removes the provider
version conflict, which is a necessary fix, but those 5 roots abort during `terraform init`'s
configuration-loading phase — before provider resolution is even attempted — on pre-existing bugs
that are out of scope here. The same errors occur on `main`; this PR neither causes nor hides them.

## Pre-existing failures newly exposed

None of these are caused by this PR. All are stale HCL on `main`. **Not fixed here** — they are a
separate piece of work.

### 1. `modules/nlb` never supplies the required `default_action_type` to `modules/nlb-listener`

Affects `examples/nlb-with-alb-target-group`, `examples/nlb-with-instance-target-group`,
`examples/nlb-with-ip-target-group` — and any consumer of `modules/nlb`.

```
│ Error: Missing required argument
│
│   on ../../modules/nlb/main.tf line 157, in module "listener":
│  157: module "listener" {
│
│ The argument "default_action_type" is required, but no definition was
│ found.
╵
╷
│ Error: Unsupported argument
│
│   on ../../modules/nlb/main.tf line 171, in module "listener":
│  171:   target_group = each.value.target_group
│
│ An argument named "target_group" is not expected here.
```

`modules/nlb/main.tf:171` passes a flat `target_group` that `modules/nlb-listener` no longer
accepts, and never supplies the now-required `default_action_type`.

### 2. Stale target-group module arguments in example `main.tf` files

`examples/alb-with-instance-target-group/main.tf` (also `alb-with-ip-target-group`, at lines
152–157 / 202–208) passes arguments `modules/alb-instance-target-group` no longer accepts:

```
│ Error: Unsupported argument
│
│   on main.tf line 151, in module "target_group_alpha":
│  151:   load_balancing_algorithm = "ROUND_ROBIN"
│
│ An argument named "load_balancing_algorithm" is not expected here.
```

Full set for the two `alb-*` roots (each reported for both `target_group_alpha` and
`target_group_beta`): `load_balancing_algorithm`, `slow_start_duration`, `stickiness_enabled`,
`stickiness_type`, `stickiness_duration`, and `stickiness_cookie` (beta only).

`examples/nlb-with-instance-target-group/main.tf` lines 80, 81, 84 and
`examples/nlb-with-ip-target-group/main.tf` lines 81, 82, 85:

```
│ Error: Unsupported argument
│
│   on main.tf line 80, in module "target_group":
│   80:   terminate_connection_on_deregistration = false
│
│ An argument named "terminate_connection_on_deregistration" is not expected
│ here.
```

plus `deregistration_delay` and `stickiness_enabled` at the following lines.

## Related PRs

Open PRs in this repo; file sets are disjoint from this one.

- #121 `chore(deps): align tedilabs child module version constraints with latest releases` — touches
  child-module `*.tf` under `modules/**`, never `examples/*/versions.tf`.
- #115 `Bump actions/checkout from 4 to 6` (dependabot, workflows only).
- #114 `Bump tj-actions/changed-files from 44 to 47` (dependabot, workflows only).

This PR touches only the 7 `examples/*/versions.tf` files.
