### PR TITLE
fix: correct stale target-group arguments and NLB listener wiring

### DIFF
--- a/examples/alb-with-instance-target-group/main.tf
+++ b/examples/alb-with-instance-target-group/main.tf
@@ -147,13 +147,17 @@ module "target_group_alpha" {
   protocol_version = "HTTP1"
 
   ## Attributes
-  deregistration_delay     = 300
-  load_balancing_algorithm = "ROUND_ROBIN"
-  slow_start_duration      = 0
+  deregistration_delay = 300
+  load_balancing = {
+    algorithm           = "ROUND_ROBIN"
+    slow_start_duration = 0
 
-  stickiness_enabled  = true
-  stickiness_type     = "LB_COOKIE"
-  stickiness_duration = 86400
+    stickiness = {
+      enabled  = true
+      type     = "LB_COOKIE"
+      duration = 86400
+    }
+  }
 
   targets = [
     # {
@@ -192,14 +196,18 @@ module "target_group_beta" {
   protocol_version = "HTTP1"
 
   ## Attributes
-  deregistration_delay     = 300
-  load_balancing_algorithm = "ROUND_ROBIN"
-  slow_start_duration      = 0
+  deregistration_delay = 300
+  load_balancing = {
+    algorithm           = "ROUND_ROBIN"
+    slow_start_duration = 0
 
-  stickiness_enabled  = true
-  stickiness_type     = "APP_COOKIE"
-  stickiness_duration = 86400
-  stickiness_cookie   = "X-TEDILABS-SESSION"
+    stickiness = {
+      enabled  = true
+      type     = "APP_COOKIE"
+      duration = 86400
+      cookie   = "X-TEDILABS-SESSION"
+    }
+  }
 
   targets = [
     # {

--- a/examples/alb-with-ip-target-group/main.tf
+++ b/examples/alb-with-ip-target-group/main.tf
@@ -148,13 +148,17 @@ module "target_group_alpha" {
   protocol_version = "HTTP1"
 
   ## Attributes
-  deregistration_delay     = 300
-  load_balancing_algorithm = "ROUND_ROBIN"
-  slow_start_duration      = 0
+  deregistration_delay = 300
+  load_balancing = {
+    algorithm           = "ROUND_ROBIN"
+    slow_start_duration = 0
 
-  stickiness_enabled  = true
-  stickiness_type     = "LB_COOKIE"
-  stickiness_duration = 86400
+    stickiness = {
+      enabled  = true
+      type     = "LB_COOKIE"
+      duration = 86400
+    }
+  }
 
   targets = [
     {
@@ -198,14 +202,18 @@ module "target_group_beta" {
   protocol_version = "HTTP1"
 
   ## Attributes
-  deregistration_delay     = 300
-  load_balancing_algorithm = "ROUND_ROBIN"
-  slow_start_duration      = 0
+  deregistration_delay = 300
+  load_balancing = {
+    algorithm           = "ROUND_ROBIN"
+    slow_start_duration = 0
 
-  stickiness_enabled  = true
-  stickiness_type     = "APP_COOKIE"
-  stickiness_duration = 86400
-  stickiness_cookie   = "X-TEDILABS-SESSION"
+    stickiness = {
+      enabled  = true
+      type     = "APP_COOKIE"
+      duration = 86400
+      cookie   = "X-TEDILABS-SESSION"
+    }
+  }
 
   targets = [
     {

--- a/examples/nlb-with-instance-target-group/main.tf
+++ b/examples/nlb-with-instance-target-group/main.tf
@@ -77,11 +77,17 @@ module "target_group" {
   protocol = "TCP"
 
   ## Attributes
-  terminate_connection_on_deregistration = false
-  deregistration_delay                   = 300
-  preserve_client_ip                     = true
-  proxy_protocol_v2                      = false
-  stickiness_enabled                     = true
+  on_deregistration = {
+    connection_termination_enabled = false
+    draining_interval              = 300
+  }
+  load_balancing = {
+    stickiness = {
+      enabled = true
+    }
+  }
+  preserve_client_ip = true
+  proxy_protocol_v2  = false
 
   targets = [
     # {

--- a/examples/nlb-with-ip-target-group/main.tf
+++ b/examples/nlb-with-ip-target-group/main.tf
@@ -78,11 +78,17 @@ module "target_group" {
   protocol        = "TCP"
 
   ## Attributes
-  terminate_connection_on_deregistration = false
-  deregistration_delay                   = 300
-  preserve_client_ip                     = true
-  proxy_protocol_v2                      = false
-  stickiness_enabled                     = true
+  on_deregistration = {
+    connection_termination_enabled = false
+    draining_interval              = 300
+  }
+  load_balancing = {
+    stickiness = {
+      enabled = true
+    }
+  }
+  preserve_client_ip = true
+  proxy_protocol_v2  = false
 
   targets = [
     {

--- a/modules/nlb/main.tf
+++ b/modules/nlb/main.tf
@@ -166,9 +166,8 @@ module "listener" {
 
   load_balancer = aws_lb.this.arn
 
-  port         = each.key
-  protocol     = each.value.protocol
-  target_group = each.value.target_group
+  port     = each.key
+  protocol = each.value.protocol
 
   ## TLS
   tls = {
@@ -176,6 +175,12 @@ module "listener" {
     additional_certificates = each.value.tls.additional_certificates
     security_policy         = each.value.tls.security_policy
     alpn_policy             = each.value.tls.alpn_policy
+  }
+
+  ## Actions
+  default_action_type = "FORWARD"
+  default_action_parameters = {
+    target_group = each.value.target_group
   }
 
   resource_group = {


### PR DESCRIPTION
## What & why

Two defects, both traceable to commit `defe1ef` ("feat(alb): support updated listener"):

1. **`modules/nlb` was broken on `main`.** That commit migrated the ALB half of the listener
   interface to `default_action_type` + `default_action_parameters`, but the NLB half was never
   updated. `modules/nlb/main.tf` still passed a flat `target_group` to `modules/nlb-listener`
   (whose `target_group` no longer exists) and never supplied its **required**
   `default_action_type`. So `modules/nlb` and every example using it failed at config load.

2. **Target-group examples still used pre-object-collapse flat arguments.**

## Changes

`modules/nlb/main.tf` — mirror the ALB mapping:

```hcl
-  port         = each.key
-  protocol     = each.value.protocol
-  target_group = each.value.target_group
+  port     = each.key
+  protocol = each.value.protocol
...
+  ## Actions
+  default_action_type = "FORWARD"
+  default_action_parameters = {
+    target_group = each.value.target_group
+  }
```

Examples, checked one by one against each module's current `variables.tf`:

| Example | Before | After |
|---|---|---|
| `alb-with-{instance,ip}-target-group` | `load_balancing_algorithm`, `slow_start_duration`, `stickiness_{enabled,type,duration,cookie}` | `load_balancing = { algorithm, slow_start_duration, stickiness = { enabled, type, duration, cookie } }` |
| `nlb-with-{instance,ip}-target-group` | `terminate_connection_on_deregistration`, `deregistration_delay`, `stickiness_enabled` | `on_deregistration = { connection_termination_enabled, draining_interval }` and `load_balancing = { stickiness = { enabled } }` |

## Verification

`terraform fmt -recursive -check .` passes. Per directory, `terraform init -backend=false` then
`terraform validate`:

| Directory | Before | After |
|---|---|---|
| `modules/nlb` | FAIL — missing required `default_action_type`; unsupported `target_group` | **OK, 0 warnings** |
| `modules/alb` | OK | OK, 0 warnings |
| `examples/nlb-with-alb-target-group` | FAIL | **OK, 0 warnings** |
| `examples/nlb-with-instance-target-group` | FAIL | **OK, 0 warnings** |
| `examples/nlb-with-ip-target-group` | FAIL | **OK, 0 warnings** |
| `examples/gwlb-with-ip-target-group` | OK | OK, 0 warnings |
| `examples/alb-with-instance-target-group` | FAIL | still FAIL — different cause, see below |
| `examples/alb-with-ip-target-group` | FAIL | still FAIL — different cause, see below |

No `terraform plan`/`apply` was run, so this is config-load and type/validation correctness only.

## Still failing — needs an owner decision

`examples/alb-with-{instance,ip}-target-group` no longer fail on target-group arguments. They now
surface a **separate typing defect in `modules/alb`**, previously masked:

```
The given value is not suitable for module.alb.var.listeners declared at
../../modules/alb/variables.tf:259,1-21: element types must all match for
conversion to list.
```

Cause: `defe1ef` changed `listeners` from `type = any` to `type = list(object({...}))` while leaving

```hcl
rules = optional(any, {})
```

nested inside it. An `any` hole inside a collection type forces Terraform to unify the element type
across **all** list elements. These examples legitimately declare heterogeneous listeners — one
`REDIRECT_301`, one `FIXED_RESPONSE` with two rules whose `action_parameters` differ
(`{ target_group }` vs `{ targets = [...] }`) — so no common type exists.

Note `modules/alb-listener` deliberately keeps `rules` as `type = any` with `default = []`, which is
fine at top level; the problem is only the nesting.

I did **not** guess at a fix. The options are a design call:

- **Type `rules` explicitly** as `optional(list(object({...})), [])` with all-optional attributes,
  following the union-object pattern the same variable already uses for `default_action_parameters`.
  Tightens the public interface and requires enumerating every supported rule/action shape.
- **Revert `listeners` to `type = any`**, keeping the freeform intent that `modules/alb-listener`
  still has. Loses the type checking `defe1ef` was adding.

I tried the minimal `optional(any, {})` → `optional(any, [])` change; it shifts the error message but
does not fix it, so I reverted it rather than ship an unverified interface change.

CI will stay red on those two directories until this is decided.
